### PR TITLE
Bugfix

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -364,12 +364,12 @@ var Query = function Query(options, cb) {
 
   log('Param values set during class creation.');
 
+  Query.prototype.exec = exec.bind(this);
+  
   if (typeof(cb) === 'function') {
     log('Class called with immediate function callback.');
     this.exec(cb);
   }
-
-  Query.prototype.exec = exec.bind(this);
 
   return this;
 };


### PR DESCRIPTION
`exec` needs to be assigned to the `prototype` before it is called. Unless you meant `exec(cb);` instead of `this.exec(cb);` I didn't really go through the rest of the code, I hope this fixes it. Nice package though! Works like a charm.
