### PR TITLE
Fixes `Invalid Date` issue.

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -204,12 +204,12 @@ var typeValue = function(value, type) {
         value = false;
       }
     } else if (type === 'datetime') {
-      let value_date = new Date(value);
-      if ( Object.prototype.toString.call(value_date) === "[object Date]" ) {
+      var valueDate = new Date(value);
+      if ( Object.prototype.toString.call(valueDate) === '[object Date]') {
         // it is a date
-        if (value_date.valueOf()) {
+        if (valueDate.valueOf()) {
           // date is valid
-          value = value_date;
+          value = valueDate;
         }
       }
     }

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -204,7 +204,14 @@ var typeValue = function(value, type) {
         value = false;
       }
     } else if (type === 'datetime') {
-      value = new Date(value);
+      let value_date = new Date(value);
+      if ( Object.prototype.toString.call(value_date) === "[object Date]" ) {
+        // it is a date
+        if (value_date.valueOf()) {
+          // date is valid
+          value = value_date;
+        }
+      }
     }
   }
   return value;


### PR DESCRIPTION
Apparently, `new Date` doesn't *always* like the date formats in Windows 10 WMI. Changes determines if this was an *invalid date* and allows the non-parsed value to be returned to the user.

Fixes #6