### PR TITLE
Parse date types that aren't auto-parsed.

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -210,6 +210,11 @@ var typeValue = function(value, type) {
         if (valueDate.valueOf()) {
           // date is valid
           value = valueDate;
+        } else {
+          var formattedDate = value.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.(\d{6})([-]\d{3})/);
+          if (formattedDate) {
+            value = new Date(Date.UTC(formattedDate[1], (formattedDate[2] - 1), formattedDate[3], (formattedDate[4] - (parseInt(formattedDate[8]) / 100)), formattedDate[5], formattedDate[6], formattedDate[7]));
+          }
         }
       }
     }


### PR DESCRIPTION
This PR builds on #7; which was just a quick fix of #6.

- Given this format of a date object in WMI: `20170414095919.000000-300`
    - Confirmed WMI date formatting on a handful of keys in Win 10, 8.1, and 7; all enterprise editions.
- The returned value will be a date object: `2017-04-14T12:59:19.000Z`
    - Code tested on Win 10 only.
    - **Notice:** that hours are adjusted to zulu time (aka: GMT) based on the offset provided by the registry date format.

The `RegExp` matched object looks like this:

```javascript
[ '20170414095919.000000-300',
  '2017',
  '04',
  '14',
  '09',
  '59',
  '19',
  '000000',
  '-300',
  index: 0,
  input: '20170414095919.000000-300' ]
```

Special considerations:
- **Month:** is what's parsed minus 1; since JS months go from 0-11.
- **Hours:** need to be adjusted to zulu time.
    - divide the timezone offset by 100: `-3.00`
    - subtract it from the hours: `9 - -3.00 = 12`